### PR TITLE
Fix problem when set "rate" too large

### DIFF
--- a/vpython/vpython.py
+++ b/vpython/vpython.py
@@ -387,6 +387,8 @@ def commsend():
                             
             if (ob is not None) and (hasattr(ob,'methodsupdt')) and (len(ob.methodsupdt) > 0 ):
                 for m in ob.methodsupdt: # a list
+                    if L >= len(commcmds):
+                        break
                     if 'attr' in commcmds[L]: del commcmds[L]['attr'] # if left over from previous use of slot
                     method = m[0]
                     data = m[1]


### PR DESCRIPTION
When set "rate" too large and ploting a gcurve in graph in the same time will cause "list index out of range" at "commcmds[L]"
The code will cause this problem: http://codepad.org/sbe1Af73
Error message: http://i.imgur.com/5HlM84y.png